### PR TITLE
fix: fix a bug `tr: write error: Broken pipe`

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -24,7 +24,8 @@ runs:
     - id: artifact-name
       shell: bash
       run: |
-        value=$(tr -dc A-Za-z0-9 </dev/urandom | head -c 32)
+        set -euo pipefail
+        value=$(tr -dc A-Za-z0-9 </dev/urandom | { head -c 32; cat >/dev/null; })
         echo "value=securefix-${value}" >> "$GITHUB_OUTPUT"
     - id: files
       shell: bash


### PR DESCRIPTION
```
Run value=$(tr -dc A-Za-z0-9 </dev/urandom | head -c 32)
tr: write error: Broken pipe
Error: Process completed with exit code 1.
```